### PR TITLE
fixed typo error in success mantras

### DIFF
--- a/app/src/main/res/layout/fragment_life_lessons.xml
+++ b/app/src/main/res/layout/fragment_life_lessons.xml
@@ -313,7 +313,7 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:gravity="center"
-                            android:text="Mind are so closely \nlinked, when your \nbody feels better so, \ntoo, will your mind."
+                            android:text="Body and Mind are \nclosely linked. When your \nbody feels better so, \ntoo, will your mind."
                             android:textColor="#000000"
                             android:textSize="12sp"
                             android:textStyle="italic" />


### PR DESCRIPTION
fixes #19: Changed text from: 
"Mind are so closely linked , when your body feels better so, too, will your mind." 
To:
"Body and Mind are closely linked. When your body feels better so, too, will your mind."

