### PR TITLE
added option to reset all task at once in weekly planner

### DIFF
--- a/app/src/main/java/com/example/inout2020_aimers/WeeklyPlanner/Database/Day.kt
+++ b/app/src/main/java/com/example/inout2020_aimers/WeeklyPlanner/Database/Day.kt
@@ -1,7 +1,9 @@
 package com.example.inout2020_aimers.WeeklyPlanner.Database
 
+import android.os.Parcelable
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlinx.android.parcel.Parcelize
 
 @Entity(tableName = "week_table")
 data class Day(

--- a/app/src/main/java/com/example/inout2020_aimers/WeeklyPlanner/Database/DayViewModel.kt
+++ b/app/src/main/java/com/example/inout2020_aimers/WeeklyPlanner/Database/DayViewModel.kt
@@ -3,10 +3,12 @@ package com.example.inout2020_aimers.WeeklyPlanner.Database
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+
 
 class DayViewModel (application: Application) : AndroidViewModel(Application()) {
 
@@ -15,6 +17,7 @@ class DayViewModel (application: Application) : AndroidViewModel(Application()) 
 
     private val repository: DayRepository
     val allDays: LiveData<List<Day>>
+    val mListLivedata = MutableLiveData<List<Day>>()
 
     init {
         val listDao = DayRoomDatabase.getDatabase(application).dayDao()
@@ -24,6 +27,59 @@ class DayViewModel (application: Application) : AndroidViewModel(Application()) 
 
     fun insert(day: Day) = scope.launch(Dispatchers.IO) {
         repository.insert(day)
+    }
+
+    fun getNewLivedata(newList: ArrayList<Day>) {
+
+        for(i in newList){
+            i.dayTask=""
+            i.done= 0
+            delete(i)
+        }
+        val day0 = Day(
+            dayTask = "",
+            dayName = "MONDAY",
+            id = 0
+        )
+        val day1 = Day(
+            dayTask = "",
+            dayName = "TUESDAY",
+            id = 1
+        )
+        val day2 = Day(
+            dayTask = "",
+            dayName = "WEDNESDAY",
+            id = 2
+        )
+        val day3 = Day(
+            dayTask = "",
+            dayName = "THURSDAY",
+            id = 3
+        )
+        val day4 = Day(
+            dayTask = "",
+            dayName = "FRIDAY",
+            id = 4
+        )
+        val day5 = Day(
+            dayTask = "",
+            dayName = "SATURDAY",
+            id = 5
+        )
+        val day6 = Day(
+            dayTask = "",
+            dayName = "SUNDAY",
+            id = 6
+        )
+        insert(day0)
+        insert(day1)
+        insert(day2)
+        insert(day3)
+        insert(day4)
+        insert(day5)
+        insert(day6)
+
+
     }
 
     fun delete(day: Day) = scope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/example/inout2020_aimers/WeeklyPlanner/WeekFragment.kt
+++ b/app/src/main/java/com/example/inout2020_aimers/WeeklyPlanner/WeekFragment.kt
@@ -3,12 +3,11 @@ package com.example.inout2020_aimers.WeeklyPlanner
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -22,6 +21,7 @@ class WeekFragment : Fragment() {
     lateinit var sharedPreferences: SharedPreferences
     private lateinit var dayViewModel: DayViewModel
     private var _binding: FragmentWeekBinding? = null
+    lateinit var newList : ArrayList<Day>
     private val binding
         get() = _binding!!
     private lateinit var dayAdapter: DayAdapter
@@ -61,10 +61,10 @@ class WeekFragment : Fragment() {
                 dayName = "THURSDAY",
                 id = 3
             )
-        val day4 = Day(
+            val day4 = Day(
                 dayTask = "",
                 dayName = "FRIDAY",
-            id = 4
+                id = 4
             )
             val day5 = Day(
                 dayTask = "",
@@ -89,6 +89,7 @@ class WeekFragment : Fragment() {
         editor?.apply()
 
         dayViewModel.allDays.observe(viewLifecycleOwner, Observer { list ->
+            newList = list as ArrayList<Day>
             dayAdapter.submitList(list)
             dayAdapter.dayList = list as ArrayList<Day>
         })
@@ -98,24 +99,19 @@ class WeekFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when(item.itemId){
             R.id.reset->{
-                val ls=ArrayList<Day>()
-                dayViewModel.allDays.observe(viewLifecycleOwner, Observer { list ->
-                    for(i in list){
-                        i.dayTask=""
-                        ls.add(i)
-                    }
-                })
-                dayViewModel.update(ls[0])
-                dayViewModel.update(ls[1])
-                dayViewModel.update(ls[2])
-                dayViewModel.update(ls[3])
-                dayViewModel.update(ls[4])
-                dayViewModel.update(ls[5])
-                dayViewModel.update(ls[6])
-                dayAdapter.submitList(ls)
-                dayAdapter.dayList=ls
+                dayViewModel.getNewLivedata(newList)
+                onResume()
             }
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    override fun onResume() {
+        dayViewModel.allDays.observe(viewLifecycleOwner, Observer { list ->
+            newList = list as ArrayList<Day>
+            dayAdapter.submitList(list)
+            dayAdapter.dayList = list as ArrayList<Day>
+        })
+        super.onResume()
     }
 }

--- a/app/src/main/java/com/example/inout2020_aimers/WeeklyPlanner/WeekFragment.kt
+++ b/app/src/main/java/com/example/inout2020_aimers/WeeklyPlanner/WeekFragment.kt
@@ -5,11 +5,14 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.inout2020_aimers.R
 import com.example.inout2020_aimers.WeeklyPlanner.Adapter.DayAdapter
 import com.example.inout2020_aimers.WeeklyPlanner.Database.Day
 import com.example.inout2020_aimers.WeeklyPlanner.Database.DayViewModel
@@ -32,6 +35,10 @@ class WeekFragment : Fragment() {
         dayAdapter = DayAdapter(dayViewModel, binding.rv.rootView)
         sharedPreferences = context?.getSharedPreferences("FIRST_OPEN", Context.MODE_PRIVATE)!!
         binding.rv.adapter = dayAdapter
+        binding.toolbarDashboard.inflateMenu(R.menu.reset_btn)
+        binding.toolbarDashboard.setOnMenuItemClickListener {
+            onOptionsItemSelected(it)
+        }
         binding.rv.layoutManager = LinearLayoutManager(context)
         if (sharedPreferences.getInt("FIRST_OPEN",0) == 0) {
             val day0 = Day(
@@ -88,4 +95,27 @@ class WeekFragment : Fragment() {
         return binding.root
     }
 
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when(item.itemId){
+            R.id.reset->{
+                val ls=ArrayList<Day>()
+                dayViewModel.allDays.observe(viewLifecycleOwner, Observer { list ->
+                    for(i in list){
+                        i.dayTask=""
+                        ls.add(i)
+                    }
+                })
+                dayViewModel.update(ls[0])
+                dayViewModel.update(ls[1])
+                dayViewModel.update(ls[2])
+                dayViewModel.update(ls[3])
+                dayViewModel.update(ls[4])
+                dayViewModel.update(ls[5])
+                dayViewModel.update(ls[6])
+                dayAdapter.submitList(ls)
+                dayAdapter.dayList=ls
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
 }

--- a/app/src/main/res/layout/item_weekday.xml
+++ b/app/src/main/res/layout/item_weekday.xml
@@ -9,7 +9,6 @@
     android:layout_marginEnd="16dp"
     android:background="@drawable/rect"
     android:orientation="vertical">
-
     <TextView
         android:id="@+id/day_name"
         android:layout_width="match_parent"
@@ -20,7 +19,6 @@
         android:text="MONDAY"
         android:textAppearance="@style/TextAppearance.AppCompat.Large"
         android:textColor="@color/black" />
-
     <TextView
         android:id="@+id/day_task"
         android:layout_width="match_parent"
@@ -59,8 +57,8 @@
 
         <ImageView
             android:id="@+id/item_bin"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:src="@drawable/ic_refresh"
             app:tint="@color/colorAccent" />
     </LinearLayout>


### PR DESCRIPTION
# Description

The reset menu option allows a  user to reset all of the weekdays planner content at once

Fixes #14 




#APK Link

https://drive.google.com/file/d/13CIGsnz2lkGfQ5tsq71AMu3_aDvZJF2Z/view?usp=sharing

